### PR TITLE
fix: added missing references to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   },
   "type": "module",
   "main": "target/cjs/index.cjs",
+  "module": "target/esm/index.mjs",
+  "types": "target/dts/index.d.ts",
   "exports": {
     ".": {
       "types": "./target/dts/index.d.ts",


### PR DESCRIPTION
Closes #4

You can see this resolution by running the following command in the example from the issue:
```sh
sed -i '' 's/"main": "target\/cjs\/index.cjs",/"main": "target\/cjs\/index.cjs",\n  "module": "target\/esm\/index.mjs",\n  "types": "target\/dts\/index.d.ts",/' node_modules/@webpod/ps/package.json
```

Then running:
```sh
pnpm tsc --noEmit
```